### PR TITLE
Add default type for apiParam

### DIFF
--- a/lib/apidocToSwagger.js
+++ b/lib/apidocToSwagger.js
@@ -343,7 +343,7 @@ function createParameters(fields, place){
 			name: field,
 			in: place,
 			required: !param.optional,
-			type: param.type.toLowerCase(),
+			type: param.type ? param.type.toLowerCase() : "string",
 			description: removeTags(param.description)
 		};
 	});


### PR DESCRIPTION
Field type in apiParam is optinal so we just need a default field as string type.